### PR TITLE
Glossary routes

### DIFF
--- a/controllers/glossaryController.js
+++ b/controllers/glossaryController.js
@@ -1,0 +1,9 @@
+const express = require('express')
+const glossary = express.Router()
+const Glossary = require('../models/glossaryModel.js')
+
+glossary.get('/', (req, res) => {
+  res.send('glossary returns something')
+})
+
+module.exports = glossary

--- a/controllers/glossaryController.js
+++ b/controllers/glossaryController.js
@@ -36,7 +36,7 @@ glossary.delete('/:id', (req, res) => {
       res.status(404).json({message: 'Word is not found'})
     }
     else {
-      res.status(200).json({message: `Word ${deletedWord.word} deleted successfully`})
+      res.status(200).json({message: `Word ${deletedWord.text} deleted successfully`})
     };
   });
 });
@@ -48,7 +48,7 @@ glossary.put('/:id', (req, res) => {
       res.status(400).json({error: error.message})
     }
     else {
-      res.status(200).json({ message: `Word ${updatedWord.word} updated successfully`, data: updatedWord })
+      res.status(200).json({ message: `Word ${updatedWord.text} updated successfully`, data: updatedWord })
     };
   });
 });
@@ -65,7 +65,7 @@ glossary.patch('/:id/addToFavorites', (req, res) => {
       word.save()
 
       res.status(200).json({
-        message: `Favorite flag for ${word.word} was set to ${word.favorite}`,
+        message: `Favorite flag for ${word.text} was set to ${word.favorite}`,
         data: word
       })
     };

--- a/controllers/glossaryController.js
+++ b/controllers/glossaryController.js
@@ -2,8 +2,74 @@ const express = require('express')
 const glossary = express.Router()
 const Glossary = require('../models/glossaryModel.js')
 
+// get list of all words
 glossary.get('/', (req, res) => {
-  res.send('glossary returns something')
-})
+  Glossary.find({}, (error, foundWords) => {
+    if (error) {
+      res.status(400).json(error)
+    }
+    else {
+      res.status(200).json(foundWords)
+    };
+  });
+});
+
+// add word to the glossary
+glossary.post('/', (req, res) => {
+  Glossary.create(req.body, (error, createdWord) => {
+    if (error) {
+      res.status(400).json({error: error.message})
+    }
+    else {
+      res.status(201).json(createdWord)
+    };
+  });
+});
+
+// delete word from the glossary
+glossary.delete('/:id', (req, res) => {
+  Glossary.findByIdAndDelete(req.params.id, (error, deletedWord) => {
+    if(error) {
+      res.status(400).json({error: error.message})
+    }
+    else if (deletedWord === null) {
+      res.status(404).json({message: 'Word is not found'})
+    }
+    else {
+      res.status(200).json({message: `Word ${deletedWord.word} deleted successfully`})
+    };
+  });
+});
+
+// update word in the glossary
+glossary.put('/:id', (req, res) => {
+  Glossary.findByIdAndUpdate(req.params.id, req.body, {new:true}, (error, updatedWord) => {
+    if (error) {
+      res.status(400).json({error: error.message})
+    }
+    else {
+      res.status(200).json({ message: `Word ${updatedWord.word} updated successfully`, data: updatedWord })
+    };
+  });
+});
+
+// add/remove word in favorites that will be used in practice game
+glossary.patch('/:id/addToFavorites', (req, res) => {
+  Glossary.findById(req.params.id, (error, word) => {
+    if (error) {
+      res.status(400).json({error: error.message})
+    }
+    else {
+      // toggle flag true/false
+      word.favorite = !word.favorite
+      word.save()
+
+      res.status(200).json({
+        message: `Favorite flag for ${word.word} was set to ${word.favorite}`,
+        data: word
+      })
+    };
+  });
+});
 
 module.exports = glossary

--- a/models/glossaryModel.js
+++ b/models/glossaryModel.js
@@ -5,6 +5,7 @@ const glossarySchema = Schema ({
   word: { type: String, required: true },
   translateFromLang: { type: String, required: true },
   translateToLang: { type: String, required: true },
+  favorite: { type: Boolean, default: false }
 }, { timestamps: true });
 
 //creating collection/model

--- a/models/glossaryModel.js
+++ b/models/glossaryModel.js
@@ -2,7 +2,8 @@ const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
 const glossarySchema = Schema ({
-  word: { type: String, required: true },
+  text: { type: String, required: true },
+  translatedText: { type: String, required: true },
   translateFromLang: { type: String, required: true },
   translateToLang: { type: String, required: true },
   favorite: { type: Boolean, default: false }

--- a/models/glossaryModel.js
+++ b/models/glossaryModel.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const glossarySchema = Schema ({
+  word: { type: String, required: true },
+  translateFromLang: { type: String, required: true },
+  translateToLang: { type: String, required: true },
+}, { timestamps: true });
+
+//creating collection/model
+const Glossary = mongoose.model('Glossary', glossarySchema);
+
+module.exports = Glossary;

--- a/server.js
+++ b/server.js
@@ -57,6 +57,7 @@ app.use('/users', require('./controllers/userController.js'))
 app.use('/sessions', require('./controllers/sessionController.js'))
 app.use('/translations', require('./controllers/googleTranslate'))
 app.use('/textToSpeech', require('./controllers/googleTextToSpeech'))
+app.use('/glossary', require('./controllers/glossaryController.js'))
 
 
  app.listen(PORT, () => {

--- a/server.js
+++ b/server.js
@@ -7,10 +7,10 @@ const app = express()
 
 const cors = require('cors')
 
-const whitelist = ['http://localhost:3060']
+const whitelist = ['http://localhost:3000']
 const corsOptions = {
-  origin: function (origin, callback) {
-    if (whitelist.indexOf(origin) !== -1) {
+  origin: (origin, callback) => {
+    if (whitelist.indexOf(origin) !== -1 || !origin) {
       callback(null, true)
     } else {
       callback(new Error('Not allowed by CORS'))


### PR DESCRIPTION
POST /glossary
	should create a word in glossary
GET /glossary
	should return a list of words
DELETE /glossary/:id
	should delete a word from glossary
PUT /glossary/:id
	should update the word in glossary
PATCH /glossary/:id
	should be able marking word as favorite for practice game

Also, updated the CORS whitelist to be able to make calls from front-end and Postman.